### PR TITLE
fix processing of shipping method

### DIFF
--- a/Model/Config/ModuleConfig.php
+++ b/Model/Config/ModuleConfig.php
@@ -191,7 +191,7 @@ class ModuleConfig implements ModuleConfigInterface
     {
         $configuredMethods = $this->getShippingMethods($store);
         foreach ($configuredMethods as $method) {
-            if (strpos($shippingMethod, $method)) {
+            if (strpos($shippingMethod, $method) !== false) {
                 return true;
             }
         }

--- a/Model/Config/ModuleConfig.php
+++ b/Model/Config/ModuleConfig.php
@@ -189,7 +189,14 @@ class ModuleConfig implements ModuleConfigInterface
      */
     public function canProcessMethod($shippingMethod, $store = null)
     {
-        return in_array($shippingMethod, $this->getShippingMethods($store));
+        $configuredMethods = $this->getShippingMethods($store);
+        foreach ($configuredMethods as $method) {
+            if (strpos($shippingMethod, $method)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Several Magento extensions use suffixes for the shipment method labels to
differentiate between the different DHL package types. For this reason no
'Create Label' checkbox is displayed in the backend for these extensions.
Because the onProcessMethods function only returns true if the label exactly
matches the extensions carrier name.

One example extension would be the 'MatrixRate Table Rate Shipping' by
WebShopApps. Which generate label names like 'matrixrate_500' for 'DHL Paket'
and 'matrixrate_509' for 'DHL Paket International', but does have the carrier
name 'matrixrate'.